### PR TITLE
Improve regex to handle code snippets "<" when using the block

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -554,7 +554,7 @@ class SyntaxHighlighter {
 			}
 		}
 
-		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
+		$code = preg_replace( '#<pre [^>]+>(.*)</pre>#s', '$1', $content );
 
 		// Undo escaping done by WordPress
 		$code = htmlspecialchars_decode( $code );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix an issue where code snippets using the `<`  character weren't correctly handled by the Syntax Highlighter block. I've seen that error happen a few times while developing #260.

### Testing instructions

TBD.


