### PR TITLE
PHP 8 Compat: declare class properties

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -31,8 +31,9 @@ class SyntaxHighlighter {
 	public $encoded              = false;    // Used to mark that a character encode took place
 	public $codeformat           = false;    // If set, SyntaxHighlighter::get_code_format() will return this value
 	public $content_save_pre_ran = false;    // It's possible for the "content_save_pre" filter to run multiple times, so keep track
+	public $brush_names          = array();  // Array of brush names for use.
+	public $specialchars         = array(); // Array of special characters to be encoded.
 
-	// Initalize the plugin by registering the hooks
 	function __construct() {
 		if ( ! function_exists( 'do_shortcodes_in_html_tags' ) )
 			return;
@@ -621,7 +622,7 @@ class SyntaxHighlighter {
 	 * Returns all shortcodes not handled by SyntaxHighlighter unchanged, so they
 	 * can be processed by their original handlers after SyntaxHighlighter has
 	 * run.
-	 * 
+	 *
 	 * @param mixed $output The shortcode's returned value (false by default).
 	 * @param string $tag The name of the shortcode.
 	 * @param array|null $attr The shortcode attributes.


### PR DESCRIPTION
Fixes #264

### Changes proposed in this Pull Request

* Declaring two class properties

### Testing instructions

* Load the plugin on a site with PHP 8.2 and confirm no depcreation warnings in the error log.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* None.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* None.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
n/a
