### PR TITLE
fix: stop double escaping in code blocks

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -555,19 +555,18 @@ class SyntaxHighlighter {
 			}
 		}
 
-		$code = preg_replace( '#<pre [^>]+>([^<]+)?</pre>#', '$1', $content );
+		$code = preg_replace( '#<pre(?: [^>]*)?>([\s\S]*?)</pre>#', '$1', $content );
 
-		$language = null;
-		if ( isset( $attributes['language'] ) ) {
-			$language = $attributes['language'];
-		}
-		if ( isset( $this->brushes[ $language ] ) )  {
-			// Undo escaping done by WordPress
-			$code = htmlspecialchars_decode( $code );
-		}
+		// Undo escaping done by WordPress
+		$code = htmlspecialchars_decode( $code );
 		$code = preg_replace( '/^(\s*https?:)&#0?47;&#0?47;([^\s<>"]+\s*)$/m', '$1//$2', $code );
 
+		// Block content is always raw at this point, so treat it as such
+		// regardless of the post's stored code format.
+		$previous_codeformat = $this->codeformat;
+		$this->codeformat = 1;
 		$code = $this->shortcode_callback( $attributes, $code, 'code' );
+		$this->codeformat = $previous_codeformat;
 
 		return '<div class="wp-block-syntaxhighlighter-code ' . esc_attr( join( ' ', $classnames ) ) . '">' . $code . '</div>';
 	}


### PR DESCRIPTION
Fixes #286

### Changes proposed in this Pull Request

* In `render_block()`, always run `htmlspecialchars_decode()` on the extracted code. Since 3.7.2 (PR #283) the decode was behind a language check, so Plain Text blocks (empty language) stayed escaped and got escaped a second time in the shortcode callback. A block with `<foo>` / `bar &` showed `&lt;foo>` / `bar &amp;` on the front end.
* Accept a bare `<pre>` tag when extracting the code. The block saves `<pre>` with no attributes, and the old pattern `#<pre [^>]+>([^<]+)?</pre>#` required an attribute and also stopped at any `<` inside the code.
* Pin the code format to raw around `shortcode_callback()`. Block content is always raw at this point, but a post stored as encoded (code format 2) would make the callback strip tags instead of escaping once.

### Testing instructions

1. Add a SyntaxHighlighter block, set language to Plain Text, enter `<foo>` and `bar &`.
2. Publish and view the post. Front end should show `<foo>` and `bar &` literally, not `&lt;foo>` / `bar &amp;`.
3. Check an older post with a SyntaxHighlighter block. It should render correctly again.
4. Check blocks with other languages and classic `[sourcecode]` shortcodes. Output should be unchanged.
