### PR TITLE
fix(block): constrain line-number gutter width on the frontend

### DIFF
--- a/src/code-block/style.scss
+++ b/src/code-block/style.scss
@@ -1,0 +1,18 @@
+/**
+ * Frontend styles for the syntaxhighlighter/code block.
+ *
+ * The block output is wrapped in a `.wp-block-syntaxhighlighter-code`
+ * container (see render_block). These rules fix the highlighter table
+ * layout inside that container only, leaving shortcode output untouched.
+ */
+
+// Keep the line-number gutter from stretching to fill the table's
+// auto width. See https://github.com/Automattic/syntaxhighlighter/issues/287
+.wp-block-syntaxhighlighter-code .syntaxhighlighter table td.gutter {
+	max-width: fit-content;
+}
+
+// Keep the gutter and code cells on the same line on narrow screens.
+.wp-block-syntaxhighlighter-code .syntaxhighlighter tr {
+	display: inline-table;
+}

--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -173,6 +173,7 @@ class SyntaxHighlighter {
 		wp_register_style( 'syntaxhighlighter-theme-fadetogrey', plugins_url( $this->shfolder . '/styles/shThemeFadeToGrey.css', __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_style( 'syntaxhighlighter-theme-midnight',   plugins_url( $this->shfolder . '/styles/shThemeMidnight.css',   __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
 		wp_register_style( 'syntaxhighlighter-theme-rdark',      plugins_url( $this->shfolder . '/styles/shThemeRDark.css',      __FILE__ ), array( 'syntaxhighlighter-core' ), $this->agshver );
+		wp_register_style( 'syntaxhighlighter-blocks-css',      plugins_url( 'dist/blocks.style.build.css', __FILE__ ), array(),                             $this->agshver );
 		// phpcs:enable
 
 		// Create list of brush aliases and map them to their real brushes
@@ -973,7 +974,7 @@ class SyntaxHighlighter {
 
 	// Output any needed scripts. This is meant for the footer.
 	function maybe_output_scripts() {
-		global $wp_styles;
+		global $post, $wp_styles;
 
 		if ( 1 == $this->settings['loadallbrushes'] ) {
 			$this->usedbrushes = array_flip( array_values( $this->brushes ) );
@@ -992,12 +993,32 @@ class SyntaxHighlighter {
 		// Stylesheets can't be in the footer, so inject them via Javascript
 		echo "<script>\n";
 		echo "	(function(){\n";
+		echo "		var blockcss = document.createElement('link');\n";
 		echo "		var corecss = document.createElement('link');\n";
 		echo "		var themecss = document.createElement('link');\n";
 
 		if ( ! is_a( $wp_styles, 'WP_Styles' ) ) {
 			$wp_styles = new WP_Styles();
 		}
+
+		// The block queries its own stylesheet below, so it needs registration data.
+		if ( ! empty( $post->post_content ) && ( has_block( 'syntaxhighlighter/code', $post->post_content ) || has_block( 'core/block', $post->post_content ) ) ) : // Reusable
+			if ( ! empty( $wp_styles->registered['syntaxhighlighter-blocks-css'] ) && ! empty( $wp_styles->registered['syntaxhighlighter-blocks-css']->src ) ) :
+				$blockcssurl = add_query_arg( 'ver', $this->agshver, $wp_styles->registered['syntaxhighlighter-blocks-css']->src );
+?>
+			var blockcssurl = "<?php echo esc_js( $blockcssurl ); ?>";
+			if ( blockcss.setAttribute ) {
+				blockcss.setAttribute( "rel", "stylesheet" );
+				blockcss.setAttribute( "type", "text/css" );
+				blockcss.setAttribute( "href", blockcssurl );
+			} else {
+				blockcss.rel = "stylesheet";
+				blockcss.href = blockcssurl;
+			}
+			document.head.appendChild( blockcss );
+<?php
+			endif; // Endif block css registered
+		endif; // Endif block present
 
 		$needcore = false;
 		if ( 'none' == $this->settings['theme'] ) {


### PR DESCRIPTION
Fixes #287

### Changes proposed in this Pull Request

* The Gutenberg block output (`.wp-block-syntaxhighlighter-code`) uses the v3 highlighter table, where `table-layout: auto` + `width: 100%` on the table and `td.code` stretches the `td.gutter` cell, so line numbers sit far from the code. On narrow screens the gutter and code cells also split onto separate rows.
* Adds two block-scoped CSS rules in `src/code-block/style.scss` (built into `dist/blocks.style.build.css`): `max-width: fit-content` on the gutter cell, and `display: inline-table` on the row so the number stays on the same line as its code.
* The file `dist/blocks.style.build.css` was built but never loaded before. It is now registered as `syntaxhighlighter-blocks-css` and injected on the frontend only when the page contains a `syntaxhighlighter/code` block (or a reusable block), using the same JS link-injection pattern `maybe_output_scripts()` already uses for the core/theme styles.
* Shortcode output (`[sourcecode]` etc.) has no block wrapper, so it is untouched.

### Testing instructions

* On a site running Twenty Twenty-Four, add a SyntaxHighlighter Code block, paste some code, and turn "Line numbers" on. Publish.
* On the frontend, the line-number column hugs the numbers instead of stretching toward the center.
* Resize the window narrow (under ~640px). Each line number stays on the same row as its code line.
* Add a classic `[sourcecode php]` shortcode on another post. Its gutter/layout looks unchanged.
* Tested manually on WordPress 6.7.2, Twenty Twenty-Four, Chrome/Firefox/Safari, with the plugin built from this branch (`npm run build`).
