### PR TITLE
Add max-height setting for code blocks

### DIFF
--- a/syntaxhighlighter.php
+++ b/syntaxhighlighter.php
@@ -101,6 +101,7 @@ class SyntaxHighlighter {
 			'collapse'       => 0,
 			'firstline'      => 1,
 			'gutter'         => 1,
+			'maxheight'      => 0, // 0 disables the max-height cap
 			'htmlscript'     => 0,
 			'light'          => 0,
 			'padlinenumbers' => 'false',
@@ -1138,6 +1139,14 @@ class SyntaxHighlighter {
 			echo "	SyntaxHighlighter.defaults['quick-code'] = false;\n";
 		}
 
+		if ( ! empty( $this->settings['maxheight'] ) ) {
+			$maxheight = (int) $this->settings['maxheight'];
+			echo "	var maxheightcss = document.createElement( 'style' );\n";
+			echo "	maxheightcss.setAttribute( 'type', 'text/css' );\n";
+			echo "	maxheightcss.appendChild( document.createTextNode( '" . esc_attr( ".syntaxhighlighter { max-height: {$maxheight}px !important; overflow-y: auto !important; }" ) . "' ) );\n";
+			echo "	document.head.appendChild( maxheightcss );\n";
+		}
+
 ?>	SyntaxHighlighter.all();
 
 	// Infinite scroll support
@@ -1490,6 +1499,14 @@ class SyntaxHighlighter {
 				</fieldset>
 			</td>
 		</tr>
+		<tr valign="top">
+			<th scope="row"><label for="syntaxhighlighter-maxheight"><?php esc_html_e( 'Max Height (in pixels)', 'syntaxhighlighter' ); ?></label></th>
+			<td>
+				<input name="syntaxhighlighter_settings[maxheight]" type="text" id="syntaxhighlighter-maxheight" value="<?php echo esc_attr( $this->settings['maxheight'] ); ?>" class="small-text" />
+				<br />
+				<?php esc_html_e( 'The maximum height of a code block before a vertical scrollbar appears. Set to 0 to disable.', 'syntaxhighlighter' ); ?>
+			</td>
+		</tr>
 	</table>
 
 	<h3><?php esc_html_e( 'Defaults', 'syntaxhighlighter' ); ?></h3>
@@ -1811,6 +1828,7 @@ class SyntaxHighlighter {
 			$settings['classname']      = ( ! empty( $settings['classname'] ) ) ? preg_replace( '/[^ A-Za-z0-9_-]*/', '', $settings['classname'] ) : '';
 			$settings['firstline']      = (int) ( ( ! empty( $settings['firstline'] ) ) ? $settings['firstline'] : $this->defaultsettings['firstline'] );
 			$settings['tabsize']        = (int) ( ( ! empty( $settings['tabsize'] ) ) ? $settings['tabsize'] : $this->defaultsettings['tabsize'] );
+			$settings['maxheight']       = (int) max( 0, ( $settings['maxheight'] ?? $this->defaultsettings['maxheight'] ) );
 		}
 
 		return $settings;


### PR DESCRIPTION
Fixes #282

### Changes proposed in this Pull Request

Adds a global "Max Height (in pixels)" setting to the SyntaxHighlighter settings page. When set, code blocks get a `max-height` with a vertical scrollbar instead of stretching the page, which addresses the reporter's request for a settings-page way to cap the length of displayed code.

The setting is off by default (`0`), so existing sites are unchanged. It applies to both shortcode and Gutenberg block output, independent of which SyntaxHighlighter engine version is active (v2 or v3). No build step is required (PHP only).

What changed in `syntaxhighlighter.php`:
- Default of `0` added to the settings defaults (disabled).
- A text input on the settings page in the first (page-level) section.
- Validation sanitizes to a non-negative integer (`0` disables).
- When set, the footer script injects a `<style>` element into `<head>`:

```css
.syntaxhighlighter {
    max-height: 300px !important;
    overflow-y: auto !important;
}
```

The `!important` rules are needed because the SyntaxHighlighter core stylesheet sets `overflow-y: hidden !important` on `.syntaxhighlighter`; the injected style comes after in source order so it wins.

I picked pixels over a line count because the SH3 engine forces an 8px line height while SH2 uses `1.1em`, so a line-based setting would render inconsistently between versions.

### Testing instructions

1. Install this branch on a WordPress site with a post that contains both a `[sourcecode]` shortcode block and a `syntaxhighlighter/code` Gutenberg block, each with 50+ lines of code.
2. Go to Settings > SyntaxHighlighter and enter `300` in "Max Height (in pixels)", then Save Changes.
3. View the post on the front end. Expected: both blocks cap their height at 300px and show a vertical scrollbar.
4. Go back to settings and enter `0`, then Save Changes. Expected: code blocks render at full height, same as before this change.
5. Repeat with the Highlighter Version setting set to both Version 3.x and Version 2.x; the cap and scrollbar should work under both.

### New/Updated Hooks

None. No new or updated actions or filters.

### Deprecated Code

None. No code is being deprecated.

### Screenshot / Video

No UI screenshots submitted for this change (settings page field only, no design change).
